### PR TITLE
Fix/7 fix failing circle ci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,14 +5,14 @@ version: 2.1
 # Orbs are reusable packages of CircleCI configuration that you may share across projects, enabling you to create encapsulated, parameterized commands, jobs, and executors that can be used across multiple projects.
 # See: https://circleci.com/docs/2.0/orb-intro/
 orbs:
-  ruby: circleci/ruby@1.4.0
+  ruby: circleci/ruby@1.8.0
 
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/2.0/configuration-reference/#jobs
 jobs:
   rspec:
     docker:
-      - image: cimg/ruby:3.1.0
+      - image: cimg/ruby:3.1.2
     executor: ruby/default
     steps:
       - checkout
@@ -22,6 +22,9 @@ jobs:
       - run:
           name: bundle install
           command: bundle install
+      - run:
+          name: rubocop
+          command: rubocop 
       - run:
           name: rspec
           command: rspec

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 AllCops:
     NewCops: enable
+    TargetRubyVersion: 2.7.0
 
 Style/ClassAndModuleChildren:
   EnforcedStyle: compact


### PR DESCRIPTION
-  Bumped circleci/ruby to 1.8.0
-  Bumped cimg/ruby to 3.1.2
-  Added step to run rubocop 
-  Added targeted ruby version in .rubocop.yml

closes #7 