### PR TITLE
Bump circleci bundle install command to 2.3.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           command: bundle -v
       - run:
           name: bundle install
-          command: bundle _2.3.10_ install
+          command: bundle _2.3.11_ install
       - run:
           name: rubocop
           command: rubocop 


### PR DESCRIPTION
CI is still breaking because the Bundler in the Docker image is 2.3.11, while the Bundle install command specifies 2.3.10.

resolve #9 